### PR TITLE
Only reset papertrail historical value once per day

### DIFF
--- a/lib/dynosaur/inputs/papertrail_input_plugin.rb
+++ b/lib/dynosaur/inputs/papertrail_input_plugin.rb
@@ -21,16 +21,13 @@ module Dynosaur
       end
 
       def retrieve
-        get_log_volume
-      end
-
-      def get_value
+        volume = get_log_volume
         today = Time.now.utc.day
         if (Time.now.utc - @interval).day == today - 1
           puts "Resetting historic data for the past day, and starting fresh."
           @recent.clear
         end
-        super
+        return volume
       end
 
       def value_to_resources(value)

--- a/spec/lib/inputs/papertrail_input_plugin_spec.rb
+++ b/spec/lib/inputs/papertrail_input_plugin_spec.rb
@@ -69,6 +69,27 @@ describe Dynosaur::Inputs::PapertrailInputPlugin do
       end
       plugin.recent.size.should eq(1)
     end
+
+    it 'only resets once' do
+      now = Time.parse '2014-10-29 23:59:55 -0000'
+      stub_papertrail_api(1024 * 1024 + 1024)
+      expect(plugin.recent).to receive(:clear).once
+      Timecop.freeze(now) do
+        plugin.estimated_resources
+      end
+
+      Timecop.freeze(now + 11) do
+        plugin.estimated_resources
+      end
+
+      Timecop.freeze(now + 21) do
+        plugin.estimated_resources
+      end
+
+      Timecop.freeze(now + 31) do
+        plugin.estimated_resources
+      end
+    end
   end
 
 end


### PR DESCRIPTION
# get_value is actually called too frequently, wherease retrieve is only

 called once every @interval
