### PR TITLE
Use addon_id instead of addon_name for the Addon Update Api call

### DIFF
--- a/lib/dynosaur/heroku_addon_manager.rb
+++ b/lib/dynosaur/heroku_addon_manager.rb
@@ -18,14 +18,25 @@ module Dynosaur
 
     def set(plan)
       if !@dry_run
-        @heroku_platform_api.addon.update(@app_name, @addon_name, {plan: get_plan_id(plan)})
+        @heroku_platform_api.addon.update(@app_name, addon_id, {plan: get_plan_id(plan)})
       end
       @current_value = plan
     end
 
+    def addon_id
+      return @addon_id ||= current_addon['id']
+    end
+
+    def current_addon
+      if @current_addon.nil?
+        addons = @heroku_platform_api.addon.list(@app_name)
+        @current_addon = addons.find { |addon| addon['addon_service']['name'] == @addon_name }
+      end
+      return @current_addon
+    end
+
     def get_current_plan
-      addons = @heroku_platform_api.addon.list(@app_name)
-      return addons.find { |addon| addon['addon_service']['name'] == @addon_name }['plan']
+      return current_addon['plan']
     end
 
     def get_plan_id(plan)

--- a/spec/lib/controllers/rediscloud_controller_plugin_spec.rb
+++ b/spec/lib/controllers/rediscloud_controller_plugin_spec.rb
@@ -74,9 +74,12 @@ describe Dynosaur::Controllers::RediscloudControllerPlugin do
   describe '#run' do
     before do
       # This is what the API returns
-      controller_plugin.heroku_manager.stub(:get_current_plan).and_return({
-        "id"=>"9368f946-7c1b-40fc-97ea-abe8722a93d6",
-        "name"=>"rediscloud:25",
+      controller_plugin.heroku_manager.stub(:current_addon).and_return({
+        "id"=>"foo",
+        "plan"=>{
+          "id"=>"9368f946-7c1b-40fc-97ea-abe8722a93d6",
+          "name"=>"rediscloud:25",
+        }
       })
     end
     it 'only scales if values are different' do


### PR DESCRIPTION
Even though this is undocumented, using the name as suggested by the doc would
return a 404:
https://devcenter.heroku.com/articles/platform-api-reference#add-on