### PR TITLE
Add Bugsnag error handler

### DIFF
--- a/dynosaur.gemspec
+++ b/dynosaur.gemspec
@@ -34,6 +34,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'activeresource'
   spec.add_dependency 'librato-metrics'
   spec.add_dependency 'aws-sdk-v1'  # for SES
+  spec.add_dependency 'bugsnag'     # optional error reporter
   spec.add_dependency 'jwt', "~> 0.1.11"
   spec.add_dependency 'faraday'
 end

--- a/lib/dynosaur/error_handler.rb
+++ b/lib/dynosaur/error_handler.rb
@@ -19,7 +19,13 @@ module Dynosaur
 
       def handle(exception)
         handlers.each do |handler|
-          handler.handle(exception)
+          begin
+            handler.handle(exception)
+          rescue StandardError => e
+            puts "Error handler caused an error! Now we're in trouble"
+            puts e.message
+            puts e.backtrace.join("\n")
+          end
         end
       end
 

--- a/lib/dynosaur/error_handler.rb
+++ b/lib/dynosaur/error_handler.rb
@@ -2,6 +2,7 @@
 require 'dynosaur/error_handler/base_handler'
 require 'dynosaur/error_handler/console'
 require 'dynosaur/error_handler/ses'
+require 'dynosaur/error_handler/bugsnag'
 
 module Dynosaur
   module ErrorHandler

--- a/lib/dynosaur/error_handler/bugsnag.rb
+++ b/lib/dynosaur/error_handler/bugsnag.rb
@@ -1,0 +1,16 @@
+require 'bugsnag'
+
+module Dynosaur::ErrorHandler
+  class Bugsnag < BaseHandler
+    def initialize(config)
+      ::Bugsnag.configure do |bugsnag_config|
+        bugsnag_config.api_key = config[:api_key]
+      end
+      super
+    end
+
+    def handle(exception)
+      ::Bugsnag.notify(exception)
+    end
+  end
+end

--- a/lib/dynosaur/version.rb
+++ b/lib/dynosaur/version.rb
@@ -1,3 +1,3 @@
 module Dynosaur
-  VERSION = "0.7.0"
+  VERSION = "0.7.1"
 end

--- a/spec/lib/dynosaur/error_handler/bugsnag_spec.rb
+++ b/spec/lib/dynosaur/error_handler/bugsnag_spec.rb
@@ -1,0 +1,16 @@
+require 'spec_helper'
+
+require 'dynosaur/error_handler/bugsnag'
+
+describe Dynosaur::ErrorHandler::Bugsnag do
+  it 'should handle exception' do
+    handler = Dynosaur::ErrorHandler::Bugsnag.new({api_key: SecureRandom.uuid})
+
+    begin
+      raise StandardError.new "Dummy Error"
+    rescue StandardError => e
+      expect(Bugsnag).to receive(:notify).with(e)
+      handler.handle(e)
+    end
+  end
+end


### PR DESCRIPTION
The SesHandler is too noisy due to API failures every now and then (we kinda knew it would be). Bugsnag allows some aggregation and filtering of exceptions and it's not a lot of code.

Docs https://bugsnag.com/docs/notifiers/ruby#how-to-install and https://bugsnag.com/docs/notifiers/ruby#sending-handled-exceptions